### PR TITLE
Relax jar-dependencies version

### DIFF
--- a/logstash-output-kinesis.gemspec
+++ b/logstash-output-kinesis.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.requirements << "jar 'com.amazonaws:aws-java-sdk-sts', '1.11.63'"
   s.requirements << "jar 'org.slf4j:slf4j-simple', '1.7.13'"
 
-  s.add_runtime_dependency 'jar-dependencies', '~> 0.3.7'
+  s.add_runtime_dependency 'jar-dependencies', '~> 0.3.4'
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"


### PR DESCRIPTION
With this small change I was able to install version 5.0.0 of kinesis output on logstash 2.4.0. Verified that it runs fine after that.

I'm using logstash 2.4.0 from tarbal and the bundled version of `jar-dependencies` is `0.3.5`. I've picked `~> 0.3.4`, because this is what used by [beats input](https://github.com/logstash-plugins/logstash-input-beats/blob/master/logstash-input-beats.gemspec#L29) for example.